### PR TITLE
[feat] 프로필 페이지 초기 구성

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -39,20 +39,8 @@ export default function ProfilePage() {
                   꾸준히 기록하고 성장하는 개발자가 되고 싶습니다.
                 </p>
 
-                {/* Stats/Tags */}
-                <div className="mb-8 flex flex-wrap justify-center gap-2 lg:justify-start">
-                  {["#Frontend", "#React", "#NextJS", "#UI/UX"].map((tag) => (
-                    <span 
-                      key={tag} 
-                      className="rounded-full bg-zinc-100 px-3 py-1 text-sm font-bold text-zinc-600 transition-colors hover:bg-orange-100 hover:text-orange-600"
-                    >
-                      {tag}
-                    </span>
-                  ))}
-                </div>
-
                 {/* Edit Button */}
-                <button className="w-full rounded-xl border-2 border-zinc-200 bg-white py-3 font-bold text-zinc-700 transition-all hover:border-orange-500 hover:text-orange-500 hover:shadow-lg hover:shadow-orange-500/10">
+                <button className="mb-8 w-full rounded-xl border-2 border-zinc-200 bg-white py-3 font-bold text-zinc-700 transition-all hover:border-orange-500 hover:text-orange-500 hover:shadow-lg hover:shadow-orange-500/10">
                   프로필 편집
                 </button>
               </div>


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #9 

### ✨️ 작업 내용

프로필 페이지 초기 구성입니다. 사용자 정보, 작성글 목록 외 아래의 포트폴리오 디스플레이는 다시 구상해봐야 할 것 같습니다.

### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!

### 📸 구현 결과
<img width="2559" height="1240" alt="image" src="https://github.com/user-attachments/assets/3bf152f6-e75f-480b-82b6-3406e4b209ec" />

<img width="2550" height="1267" alt="image" src="https://github.com/user-attachments/assets/4e55d58c-adab-486b-99d0-bf9e03049b28" />
