### PR TITLE
[refactor] 요청 전역 api 설정 및 글쓰기 백엔드 요청 보내기

### DIFF
--- a/app/post-publish/page.tsx
+++ b/app/post-publish/page.tsx
@@ -13,6 +13,7 @@ import {
   UserIcon,
 } from "lucide-react";
 import { motion } from "framer-motion";
+import { api } from "../../lib/api";
 
 export default function PostPublishPage() {
   // State for the new post
@@ -145,6 +146,39 @@ export default function PostPublishPage() {
       console.error("Failed to get AI recommendations", error);
     } finally {
       setIsRecommending(false);
+    }
+  };
+
+  const handlePublish = async () => {
+    const body = {
+      name: post.title,
+      period: post.duration,
+      personnel: post.teamSize,
+      intent: post.goal,
+      my_role: post.role,
+      sale_status: post.visibility === "paid" ? "SALE" : "NOTSALE",
+      is_free: post.visibility === "free",
+      price: post.price,
+      result_url: post.resultLink,
+      failure_category: post.tags,
+      failure: post.failures.map((f) => ({ [f.tag]: [f.question, f.answer] })),
+      growth_point: post.lessons,
+    };
+
+    try {
+      const data = await api.post("/projects", body);
+
+      if (data.success) {
+        alert(data.message || "게시글이 성공적으로 등록되었습니다.");
+        window.location.href = "/";
+      } else {
+        alert(`오류 발생: ${data.message} (Code: ${data.code})`);
+      }
+    } catch (error) {
+      console.error("Publish error:", error);
+      if (error instanceof Error && error.message !== "Unauthorized") {
+        alert("게시 중 오류가 발생했습니다.");
+      }
     }
   };
 
@@ -559,7 +593,10 @@ export default function PostPublishPage() {
 
         {/* Save Button (Moved to Bottom) */}
         <div className="mt-12 flex justify-end border-t border-zinc-100 pt-8">
-          <button className="flex items-center gap-2 rounded-lg bg-zinc-900 px-8 py-3 text-base font-bold text-white transition-colors hover:bg-zinc-700">
+          <button
+            onClick={handlePublish}
+            className="flex items-center gap-2 rounded-lg bg-zinc-900 px-8 py-3 text-base font-bold text-white transition-colors hover:bg-zinc-700"
+          >
             <SaveIcon className="h-5 w-5" />
             게시하기
           </button>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,57 @@
+const BASE_URL = "https://ccscaps.com/api";
+
+type RequestMethod = "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+
+async function request<T>(
+  endpoint: string,
+  method: RequestMethod,
+  body?: any
+): Promise<T> {
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem("accessToken") : null;
+
+  const headers: HeadersInit = {
+    "Content-Type": "application/json",
+  };
+
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+
+  try {
+    const response = await fetch(`${BASE_URL}${endpoint}`, {
+      method,
+      headers,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    // Handle 401 Unauthorized globally
+    if (response.status === 401) {
+      if (typeof window !== "undefined") {
+        localStorage.removeItem("accessToken");
+        alert(
+          "로그인이 필요하거나 세션이 만료되었습니다. 다시 로그인해주세요."
+        );
+        window.location.href = "/login";
+      }
+      throw new Error("Unauthorized");
+    }
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error("API Request Error:", error);
+    throw error;
+  }
+}
+
+export const api = {
+  get: <T = any>(endpoint: string) => request<T>(endpoint, "GET"),
+  post: <T = any>(endpoint: string, body: any) =>
+    request<T>(endpoint, "POST", body),
+  put: <T = any>(endpoint: string, body: any) =>
+    request<T>(endpoint, "PUT", body),
+  delete: <T = any>(endpoint: string) => request<T>(endpoint, "DELETE"),
+  patch: <T = any>(endpoint: string, body: any) =>
+    request<T>(endpoint, "PATCH", body),
+};


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #50 

### ✨️ 작업 내용

API 요청 시 전역적으로 사용할 api.ts를 만들었고, 글쓰기(publish)에서 백엔드에 요청을 보내고 응답을 받는 구조를 만듬

### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.